### PR TITLE
Add Wi-Fi configuration options

### DIFF
--- a/app/base_application/src/main.c
+++ b/app/base_application/src/main.c
@@ -56,9 +56,9 @@ int main()
 
     wifi_args.security = WIFI_SECURITY_TYPE_PSK;
     wifi_args.channel = 13;
-    wifi_args.psk = "";
+    wifi_args.psk = CONFIG_MICROROS_WIFI_PASSWORD;
     wifi_args.psk_length = strlen(wifi_args.psk);
-    wifi_args.ssid = "";
+    wifi_args.ssid = CONFIG_MICROROS_WIFI_SSID;
     wifi_args.ssid_length = strlen(wifi_args.ssid);
     wifi_args.timeout = 0;
 


### PR DESCRIPTION
This pull request includes changes to configure WiFi settings in the `app/base_application` project. Add WiFi credentials to the configuration file and the use of these credentials in the main application code.

WiFi configuration:

* [`app/base_application/prj.conf`](diffhunk://#diff-c29a3e6cbb89150a0978d378abcbe0b119222ba5b6c58f87e1126e8c1a153414R67-R68): Added configuration entries for WiFi SSID and password.

Main application code:

* [`app/base_application/src/main.c`](diffhunk://#diff-fa00b9d2f9064c1ec4af8f029e98e2efb5368e911d7ca198ffc503c4e12e9137L59-R61): Updated the WiFi arguments to use the configured SSID and password.